### PR TITLE
uniformScale을 시작하는 시점에 이미 uniform이 아닌 경우 같은 비율로

### DIFF
--- a/Engine/Editor/Private/Editor.cpp
+++ b/Engine/Editor/Private/Editor.cpp
@@ -248,8 +248,11 @@ FVector UEditor::GetGizmoDragScale(FRay& WorldRay)
 		FVector DragStartScale = Gizmo.GetDragStartActorScale();
 		if (ScaleFactor > MinScale)
 		{
-			if(Gizmo.GetSelectedActor()->IsUniformScale())
-				return DragStartScale + FVector(1,1,1)* (ScaleFactor - 1);
+			if (Gizmo.GetSelectedActor()->IsUniformScale())
+			{
+				float UniformValue = DragStartScale.Dot(GizmoAxis);
+				return FVector(UniformValue, UniformValue, UniformValue) + FVector(1, 1, 1) * (ScaleFactor - 1);
+			}
 			else
 				return DragStartScale + GizmoAxis * (ScaleFactor - 1) * DragStartScale.Dot(GizmoAxis);
 		}

--- a/Engine/Editor/Private/Editor.cpp
+++ b/Engine/Editor/Private/Editor.cpp
@@ -251,7 +251,7 @@ FVector UEditor::GetGizmoDragScale(FRay& WorldRay)
 			if (Gizmo.GetSelectedActor()->IsUniformScale())
 			{
 				float UniformValue = DragStartScale.Dot(GizmoAxis);
-				return FVector(UniformValue, UniformValue, UniformValue) + FVector(1, 1, 1) * (ScaleFactor - 1);
+				return FVector(UniformValue, UniformValue, UniformValue) + FVector(1, 1, 1) * (ScaleFactor - 1)* UniformValue;
 			}
 			else
 				return DragStartScale + GizmoAxis * (ScaleFactor - 1) * DragStartScale.Dot(GizmoAxis);


### PR DESCRIPTION
scale되지만 축끼리 다른 값을 갖는 현상 fix